### PR TITLE
[Feature:Autograding] Add AnalysisToolsTS

### DIFF
--- a/components/analysis_tools_ts/Dockerfile.body
+++ b/components/analysis_tools_ts/Dockerfile.body
@@ -1,5 +1,5 @@
 
-ENV AnalysisToolsTS_Version v22.08.02
+ENV AnalysisToolsTS_Version v23.06.01
 ENV SUBMITTY_INSTALL_DIR /usr/local/submitty
 
 RUN apt-get update \

--- a/components/analysis_tools_ts/Dockerfile.body
+++ b/components/analysis_tools_ts/Dockerfile.body
@@ -7,6 +7,6 @@ RUN apt-get update \
     && mkdir -p ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build \
     && wget -nv "https://github.com/Submitty/AnalysisToolsTS/releases/download/${AnalysisToolsTS_Version}/submitty_count_ts" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build/submitty_count_ts \
     && wget -nv "https://github.com/Submitty/AnalysisToolsTS/releases/download/${AnalysisToolsTS_Version}/submitty_diagnostics_ts" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build/submitty_diagnostics_ts \
-    && chmod -R 755 ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools \
+    && chmod -R 755 ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS \
     && apt-get purge -y --auto-remove wget \
     && rm -rf /var/lib/apt/lists/*

--- a/components/analysis_tools_ts/Dockerfile.body
+++ b/components/analysis_tools_ts/Dockerfile.body
@@ -1,0 +1,12 @@
+
+ENV AnalysisToolsTS_Version v22.08.02
+ENV SUBMITTY_INSTALL_DIR /usr/local/submitty
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && mkdir -p ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build \
+    && wget -nv "https://github.com/Submitty/AnalysisToolsTS/releases/download/${AnalysisToolsTS_Version}/submitty_count_ts" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build/submitty_count_ts \
+    && wget -nv "https://github.com/Submitty/AnalysisToolsTS/releases/download/${AnalysisToolsTS_Version}/submitty_diagnostics_ts" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build/submitty_diagnostics_ts \
+    && chmod -R 755 ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools \
+    && apt-get purge -y --auto-remove wget \
+    && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/submitty/autograding-default/Dockerfile
+++ b/dockerfiles/submitty/autograding-default/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get install -qqy imagemagick
 ENV DRMEMORY_TAG release_2.0.1
 ENV DRMEMORY_VERSION 2.0.1-2
 ENV AnalysisTools_Version v.18.06.00
+ENV AnalysisToolsTS_Version v22.08.02
 ENV SUBMITTY_INSTALL_DIR /usr/local/submitty
 
 RUN apt-get update \
@@ -35,6 +36,9 @@ RUN apt-get update \
     && wget -nv "https://github.com/Submitty/AnalysisTools/releases/download/${AnalysisTools_Version}/count" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools/count \
     && wget -nv "https://github.com/Submitty/AnalysisTools/releases/download/${AnalysisTools_Version}/plagiarism" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools/plagiarism \
     && wget -nv "https://github.com/Submitty/AnalysisTools/releases/download/${AnalysisTools_Version}/diagnostics" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools/diagnostics \
+    && mkdir -p ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build \
+    && wget -nv "https://github.com/Submitty/AnalysisToolsTS/releases/download/${AnalysisToolsTS_Version}/submitty_count_ts" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build/submitty_count_ts \
+    && wget -nv "https://github.com/Submitty/AnalysisToolsTS/releases/download/${AnalysisToolsTS_Version}/submitty_diagnostics_ts" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build/submitty_diagnostics_ts \
     && apt-get purge -y --auto-remove wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/submitty/autograding-default/Dockerfile
+++ b/dockerfiles/submitty/autograding-default/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get install -qqy imagemagick
 
 ENV DRMEMORY_TAG release_2.5.0
 ENV DRMEMORY_VERSION 2.5.0
-ENV AnalysisTools_Version v.18.06.00
-ENV AnalysisToolsTS_Version v22.08.02
+ENV AnalysisTools_Version v.22.03.00
+ENV AnalysisToolsTS_Version v24.06.01
 ENV SUBMITTY_INSTALL_DIR /usr/local/submitty
 
 RUN apt-get update \

--- a/dockerfiles/submitty/autograding-default/Dockerfile
+++ b/dockerfiles/submitty/autograding-default/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update \
     && mkdir -p ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build \
     && wget -nv "https://github.com/Submitty/AnalysisToolsTS/releases/download/${AnalysisToolsTS_Version}/submitty_count_ts" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build/submitty_count_ts \
     && wget -nv "https://github.com/Submitty/AnalysisToolsTS/releases/download/${AnalysisToolsTS_Version}/submitty_diagnostics_ts" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build/submitty_diagnostics_ts \
+    && chmod -R 755 ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS \
     && apt-get purge -y --auto-remove wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/submittyrpi/csci1200/default/Dockerfile
+++ b/dockerfiles/submittyrpi/csci1200/default/Dockerfile
@@ -72,7 +72,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 
-ENV AnalysisToolsTS_Version v22.08.02
+ENV AnalysisToolsTS_Version v23.06.01
 ENV SUBMITTY_INSTALL_DIR /usr/local/submitty
 
 RUN apt-get update \

--- a/dockerfiles/submittyrpi/csci1200/default/Dockerfile
+++ b/dockerfiles/submittyrpi/csci1200/default/Dockerfile
@@ -60,4 +60,16 @@ RUN apt-get update \
     && apt-get purge -y --auto-remove wget \
     && rm -rf /var/lib/apt/lists/*
 
+
+ENV AnalysisToolsTS_Version v22.08.02
+ENV SUBMITTY_INSTALL_DIR /usr/local/submitty
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && mkdir -p ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build \
+    && wget -nv "https://github.com/Submitty/AnalysisToolsTS/releases/download/${AnalysisToolsTS_Version}/submitty_count_ts" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build/submitty_count_ts \
+    && wget -nv "https://github.com/Submitty/AnalysisToolsTS/releases/download/${AnalysisToolsTS_Version}/submitty_diagnostics_ts" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build/submitty_diagnostics_ts \
+    && chmod -R 755 ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools \
+    && apt-get purge -y --auto-remove wget \
+    && rm -rf /var/lib/apt/lists/*
 CMD ["/bin/bash"]

--- a/dockerfiles/submittyrpi/csci1200/default/Dockerfile
+++ b/dockerfiles/submittyrpi/csci1200/default/Dockerfile
@@ -69,7 +69,7 @@ RUN apt-get update \
     && mkdir -p ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build \
     && wget -nv "https://github.com/Submitty/AnalysisToolsTS/releases/download/${AnalysisToolsTS_Version}/submitty_count_ts" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build/submitty_count_ts \
     && wget -nv "https://github.com/Submitty/AnalysisToolsTS/releases/download/${AnalysisToolsTS_Version}/submitty_diagnostics_ts" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build/submitty_diagnostics_ts \
-    && chmod -R 755 ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools \
+    && chmod -R 755 ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS \
     && apt-get purge -y --auto-remove wget \
     && rm -rf /var/lib/apt/lists/*
 CMD ["/bin/bash"]

--- a/dockerfiles/submittyrpi/csci1200/default/metadata.json
+++ b/dockerfiles/submittyrpi/csci1200/default/metadata.json
@@ -9,6 +9,7 @@
     "drmemory",
     "valgrind",
     "imagemagick",
-    "analysis_tools"
+    "analysis_tools",
+    "analysis_tools_ts"
   ]
 }


### PR DESCRIPTION
Updated the `autograding_default` and `csci1200` DockerFIles.
In a draft state because giving an error when running command inside the container saying 1`/lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.27' not found`. 