### PR TITLE
Github action for Docker Hub

### DIFF
--- a/.github/workflows/dockerhub_push.yml
+++ b/.github/workflows/dockerhub_push.yml
@@ -1,0 +1,271 @@
+name: Push to Docker Hub
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+
+  push-images-submitty:
+    name: Push docker images (submitty)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v3
+    - name: Docker Hub login
+      uses: docker/login-action@releases/v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME_SUBMITTY }}
+        password: ${{ secrets.DOCKER_PASSWORD_SUBMITTY }}
+
+    - name: Build and push submitty/clang:3.8
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submitty/clang/3.8
+        push: true
+        tags: submitty/clang:3.8
+
+    - name: Build and push submitty/clang:4.0
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submitty/clang/4.0
+        push: true
+        tags: submitty/clang:4.0
+
+    - name: Build and push submitty/clang:5.0
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submitty/clang/5.0
+        push: true
+        tags: submitty/clang:5.0
+
+    - name: Build and push submitty/clang:6.0
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submitty/clang/6.0
+        push: true
+        tags: submitty/clang:6.0
+
+    - name: Build and push submitty/clang:7
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submitty/clang/7
+        push: true
+        tags: submitty/clang:7
+
+    - name: Build and push submitty/clang:8
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submitty/clang/8
+        push: true
+        tags: submitty/clang:8
+
+    - name: Build and push submitty/java:11
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submitty/java/11
+        push: true
+        tags: submitty/java:11
+
+    - name: Build and push submitty/java:8
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submitty/java/8
+        push: true
+        tags: submitty/java:8
+
+    - name: Build and push submitty/php:7.3-cli
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submitty/php/7.3-cli
+        push: true
+        tags: submitty/php:7.3-cli
+
+    - name: Build and push submitty/python:2.7
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submitty/python/2.7
+        push: true
+        tags: submitty/python:2.7
+
+    - name: Build and push submitty/python:3.5
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submitty/python/3.5
+        push: true
+        tags: submitty/python:3.5
+
+    - name: Build and push submitty/python:3.6
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submitty/python/3.6
+        push: true
+        tags: submitty/python:3.6
+
+    - name: Build and push submitty/python:3.7
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submitty/python/3.7
+        push: true
+        tags: submitty/python:3.7
+
+    - name: Build and push submitty/tutorial:database_client
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submitty/tutorial/database_client
+        push: true
+        tags: submitty/tutorial:database_client
+
+  push-images-submittyrpi:
+    name: Push docker images (submittyrpi)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v3
+    - name: Docker Hub login
+      uses: docker/login-action@releases/v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME_SUBMITTYRPI }}
+        password: ${{ secrets.DOCKER_PASSWORD_SUBMITTYRPI }}
+
+    - name: Build and push submittyrpi/csci1200:default
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci1200/default
+        push: true
+        tags: submittyrpi/csci1200:default
+
+    - name: Build and push submittyrpi/csci2500:gdb
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci2500/gdb
+        push: true
+        tags: submittyrpi/csci2500:gdb
+
+    - name: Build and push submittyrpi/csci2500:spim
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci2500/spim
+        push: true
+        tags: submittyrpi/csci2500:spim
+
+    - name: Build and push submittyrpi/csci2600:java_tools
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci2600/java_tools
+        push: true
+        tags: submittyrpi/csci2600:java_tools
+
+    - name: Build and push submittyrpi/csci2600:java_tools_dafny
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci2600/java_tools_dafny
+        push: true
+        tags: submittyrpi/csci2600:java_tools_dafny
+
+    - name: Build and push submittyrpi/csci4220:instructor_python
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4220/instructor_python
+        push: true
+        tags: submittyrpi/csci4220:instructor_python
+
+    - name: Build and push submittyrpi/csci4270:latest
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4270/20190912
+        push: true
+        tags: submittyrpi/csci4270:latest
+
+    - name: Build and push submittyrpi/csci4270:20210121
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4270/20210121
+        push: true
+        tags: submittyrpi/csci4270:20210121
+
+    - name: Build and push submittyrpi/csci4380:latest
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4380/latest
+        push: true
+        tags: submittyrpi/csci4380:latest
+
+    - name: Build and push submittyrpi/csci4430:prolog_20191122
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4430/prolog_20191122
+        push: true
+        tags: submittyrpi/csci4430:prolog_20191122
+
+    - name: Build and push submittyrpi/csci4450:soot
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4450/soot
+        push: true
+        tags: submittyrpi/csci4450:soot
+
+    - name: Build and push submittyrpi/csci4510:combined
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4510/combined
+        push: true
+        tags: submittyrpi/csci4510:combined
+
+    - name: Build and push submittyrpi/csci4510:default
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4510/default
+        push: true
+        tags: submittyrpi/csci4510:default
+
+    - name: Build and push submittyrpi/csci4510:go
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4510/go
+        push: true
+        tags: submittyrpi/csci4510:go
+
+    - name: Build and push submittyrpi/csci4510:java-11
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4510/java-11
+        push: true
+        tags: submittyrpi/csci4510:java-11
+
+    - name: Build and push submittyrpi/csci4510:java-8
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4510/java-8
+        push: true
+        tags: submittyrpi/csci4510:java-8
+
+    - name: Build and push submittyrpi/csci4510:project2
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4510/project2
+        push: true
+        tags: submittyrpi/csci4510:project2
+
+    - name: Build and push submittyrpi/csci4510:python-3.6
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4510/python-3.6
+        push: true
+        tags: submittyrpi/csci4510:python-3.6
+
+    - name: Build and push submittyrpi/csci4510:rust
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4510/rust
+        push: true
+        tags: submittyrpi/csci4510:rust
+
+    - name: Build and push submittyrpi/phil4140:aris
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/phil4140/aris
+        push: true
+        tags: submittyrpi/phil4140:aris
+

--- a/.github/workflows/dockerhub_push.yml
+++ b/.github/workflows/dockerhub_push.yml
@@ -7,9 +7,69 @@ on:
 
 jobs:
 
+  # this job checks which containers for account "submitty" should be updated
+  check-files-submitty:
+    name: Check modified files (submitty)
+    runs-on: ubuntu-latest
+    # variables that tell which containers should be updated
+    outputs:
+      clang__tag_3_8: ${{ steps.check-files-submitty.outputs.clang__tag_3_8 }}
+      clang__tag_4_0: ${{ steps.check-files-submitty.outputs.clang__tag_4_0 }}
+      clang__tag_5_0: ${{ steps.check-files-submitty.outputs.clang__tag_5_0 }}
+      clang__tag_6_0: ${{ steps.check-files-submitty.outputs.clang__tag_6_0 }}
+      clang__tag_7: ${{ steps.check-files-submitty.outputs.clang__tag_7 }}
+      clang__tag_8: ${{ steps.check-files-submitty.outputs.clang__tag_8 }}
+      java__tag_11: ${{ steps.check-files-submitty.outputs.java__tag_11 }}
+      java__tag_8: ${{ steps.check-files-submitty.outputs.java__tag_8 }}
+      php__tag_7_3_cli: ${{ steps.check-files-submitty.outputs.php__tag_7_3_cli }}
+      python__tag_2_7: ${{ steps.check-files-submitty.outputs.python__tag_2_7 }}
+      python__tag_3_5: ${{ steps.check-files-submitty.outputs.python__tag_3_5 }}
+      python__tag_3_6: ${{ steps.check-files-submitty.outputs.python__tag_3_6 }}
+      python__tag_3_7: ${{ steps.check-files-submitty.outputs.python__tag_3_7 }}
+      tutorial__database_client: ${{ steps.check-files-submitty.outputs.tutorial__database_client }}
+    steps:
+    - name: Code checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - name: Look for modified files
+      id: check-files-submitty
+      # look for whether any files were modified in the container's directory
+      run: |
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submitty/clang/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "clang__tag_3_8=true" >> $GITHUB_OUTPUT; else echo "clang__tag_3_8=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submitty/clang/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "clang__tag_4_0=true" >> $GITHUB_OUTPUT; else echo "clang__tag_4_0=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submitty/clang/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "clang__tag_5_0=true" >> $GITHUB_OUTPUT; else echo "clang__tag_5_0=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submitty/clang/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "clang__tag_6_0=true" >> $GITHUB_OUTPUT; else echo "clang__tag_6_0=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submitty/clang/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "clang__tag_7=true" >> $GITHUB_OUTPUT; else echo "clang__tag_7=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submitty/clang/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "clang__tag_8=true" >> $GITHUB_OUTPUT; else echo "clang__tag_8=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submitty/java/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "java__tag_11=true" >> $GITHUB_OUTPUT; else echo "java__tag_11=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submitty/java/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "java__tag_8=true" >> $GITHUB_OUTPUT; else echo "java__tag_8=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submitty/php/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "php__tag_7_3_cli=true" >> $GITHUB_OUTPUT; else echo "php__tag_7_3_cli=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submitty/python/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "python__tag_2_7=true" >> $GITHUB_OUTPUT; else echo "python__tag_2_7=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submitty/python/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "python__tag_3_5=true" >> $GITHUB_OUTPUT; else echo "python__tag_3_5=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submitty/python/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "python__tag_3_6=true" >> $GITHUB_OUTPUT; else echo "python__tag_3_6=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submitty/python/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "python__tag_3_7=true" >> $GITHUB_OUTPUT; else echo "python__tag_3_7=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submitty/tutorial/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "tutorial__database_client=true" >> $GITHUB_OUTPUT; else echo "tutorial__database_client=false" >> $GITHUB_OUTPUT; fi;
+
+  # this job pushes container images for account "submitty"
   push-images-submitty:
     name: Push docker images (submitty)
     runs-on: ubuntu-latest
+    needs: check-files-submitty
     steps:
     - name: Check out repo
       uses: actions/checkout@v3
@@ -20,6 +80,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD_SUBMITTY }}
 
     - name: Build and push submitty/clang:3.8
+      if: needs.check-files-submitty.outputs.clang__tag_3_8 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submitty/clang/3.8
@@ -27,6 +88,7 @@ jobs:
         tags: submitty/clang:3.8
 
     - name: Build and push submitty/clang:4.0
+      if: needs.check-files-submitty.outputs.clang__tag_4_0 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submitty/clang/4.0
@@ -34,6 +96,7 @@ jobs:
         tags: submitty/clang:4.0
 
     - name: Build and push submitty/clang:5.0
+      if: needs.check-files-submitty.outputs.clang__tag_5_0 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submitty/clang/5.0
@@ -41,6 +104,7 @@ jobs:
         tags: submitty/clang:5.0
 
     - name: Build and push submitty/clang:6.0
+      if: needs.check-files-submitty.outputs.clang__tag_6_0 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submitty/clang/6.0
@@ -48,6 +112,7 @@ jobs:
         tags: submitty/clang:6.0
 
     - name: Build and push submitty/clang:7
+      if: needs.check-files-submitty.outputs.clang__tag_7 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submitty/clang/7
@@ -55,6 +120,7 @@ jobs:
         tags: submitty/clang:7
 
     - name: Build and push submitty/clang:8
+      if: needs.check-files-submitty.outputs.clang__tag_8 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submitty/clang/8
@@ -62,6 +128,7 @@ jobs:
         tags: submitty/clang:8
 
     - name: Build and push submitty/java:11
+      if: needs.check-files-submitty.outputs.java__tag_11 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submitty/java/11
@@ -69,6 +136,7 @@ jobs:
         tags: submitty/java:11
 
     - name: Build and push submitty/java:8
+      if: needs.check-files-submitty.outputs.java__tag_8 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submitty/java/8
@@ -76,6 +144,7 @@ jobs:
         tags: submitty/java:8
 
     - name: Build and push submitty/php:7.3-cli
+      if: needs.check-files-submitty.outputs.php__tag_7_3_cli == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submitty/php/7.3-cli
@@ -83,6 +152,7 @@ jobs:
         tags: submitty/php:7.3-cli
 
     - name: Build and push submitty/python:2.7
+      if: needs.check-files-submitty.outputs.python__tag_2_7 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submitty/python/2.7
@@ -90,6 +160,7 @@ jobs:
         tags: submitty/python:2.7
 
     - name: Build and push submitty/python:3.5
+      if: needs.check-files-submitty.outputs.python__tag_3_5 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submitty/python/3.5
@@ -97,6 +168,7 @@ jobs:
         tags: submitty/python:3.5
 
     - name: Build and push submitty/python:3.6
+      if: needs.check-files-submitty.outputs.python__tag_3_6 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submitty/python/3.6
@@ -104,6 +176,7 @@ jobs:
         tags: submitty/python:3.6
 
     - name: Build and push submitty/python:3.7
+      if: needs.check-files-submitty.outputs.python__tag_3_7 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submitty/python/3.7
@@ -111,15 +184,94 @@ jobs:
         tags: submitty/python:3.7
 
     - name: Build and push submitty/tutorial:database_client
+      if: needs.check-files-submitty.outputs.tutorial__database_client == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submitty/tutorial/database_client
         push: true
         tags: submitty/tutorial:database_client
 
+  # this job checks which containers for account "submittyrpi" should be updated
+  check-files-submittyrpi:
+    name: Check modified files (submittyrpi)
+    runs-on: ubuntu-latest
+    # variables that tell which containers should be updated
+    outputs:
+      csci1200__default: ${{ steps.check-files-submittyrpi.outputs.csci1200__default }}
+      csci2500__gdb: ${{ steps.check-files-submittyrpi.outputs.csci2500__gdb }}
+      csci2500__spim: ${{ steps.check-files-submittyrpi.outputs.csci2500__spim }}
+      csci2600__java_tools: ${{ steps.check-files-submittyrpi.outputs.csci2600__java_tools }}
+      csci2600__java_tools_dafny: ${{ steps.check-files-submittyrpi.outputs.csci2600__java_tools_dafny }}
+      csci4220__instructor_python: ${{ steps.check-files-submittyrpi.outputs.csci4220__instructor_python }}
+      csci4270__tag_20210121: ${{ steps.check-files-submittyrpi.outputs.csci4270__tag_20210121 }}
+      csci4270__latest: ${{ steps.check-files-submittyrpi.outputs.csci4270__latest }}
+      csci4380__latest: ${{ steps.check-files-submittyrpi.outputs.csci4380__latest }}
+      csci4430__prolog_20191122: ${{ steps.check-files-submittyrpi.outputs.csci4430__prolog_20191122 }}
+      csci4450__soot: ${{ steps.check-files-submittyrpi.outputs.csci4450__soot }}
+      csci4510__combined: ${{ steps.check-files-submittyrpi.outputs.csci4510__combined }}
+      csci4510__default: ${{ steps.check-files-submittyrpi.outputs.csci4510__default }}
+      csci4510__go: ${{ steps.check-files-submittyrpi.outputs.csci4510__go }}
+      csci4510__java_11: ${{ steps.check-files-submittyrpi.outputs.csci4510__java_11 }}
+      csci4510__java_8: ${{ steps.check-files-submittyrpi.outputs.csci4510__java_8 }}
+      csci4510__project2: ${{ steps.check-files-submittyrpi.outputs.csci4510__project2 }}
+      csci4510__python_3_6: ${{ steps.check-files-submittyrpi.outputs.csci4510__python_3_6 }}
+      csci4510__rust: ${{ steps.check-files-submittyrpi.outputs.csci4510__rust }}
+      phil4140__aris: ${{ steps.check-files-submittyrpi.outputs.phil4140__aris }}
+    steps:
+    - name: Code checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - name: Look for modified files
+      id: check-files-submittyrpi
+      # look for whether any files were modified in the container's directory
+      run: |
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci1200/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci1200__default=true" >> $GITHUB_OUTPUT; else echo "csci1200__default=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci2500/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci2500__gdb=true" >> $GITHUB_OUTPUT; else echo "csci2500__gdb=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci2500/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci2500__spim=true" >> $GITHUB_OUTPUT; else echo "csci2500__spim=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci2600/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci2600__java_tools=true" >> $GITHUB_OUTPUT; else echo "csci2600__java_tools=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci2600/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci2600__java_tools_dafny=true" >> $GITHUB_OUTPUT; else echo "csci2600__java_tools_dafny=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci4220/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci4220__instructor_python=true" >> $GITHUB_OUTPUT; else echo "csci4220__instructor_python=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci4270/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci4270__tag_20210121=true" >> $GITHUB_OUTPUT; else echo "csci4270__tag_20210121=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci4270/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci4270__latest=true" >> $GITHUB_OUTPUT; else echo "csci4270__latest=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci4380/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci4380__latest=true" >> $GITHUB_OUTPUT; else echo "csci4380__latest=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci4430/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci4430__prolog_20191122=true" >> $GITHUB_OUTPUT; else echo "csci4430__prolog_20191122=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci4450/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci4450__soot=true" >> $GITHUB_OUTPUT; else echo "csci4450__soot=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci4510/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci4510__combined=true" >> $GITHUB_OUTPUT; else echo "csci4510__combined=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci4510/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci4510__default=true" >> $GITHUB_OUTPUT; else echo "csci4510__default=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci4510/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci4510__go=true" >> $GITHUB_OUTPUT; else echo "csci4510__go=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci4510/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci4510__java_11=true" >> $GITHUB_OUTPUT; else echo "csci4510__java_11=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci4510/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci4510__java_8=true" >> $GITHUB_OUTPUT; else echo "csci4510__java_8=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci4510/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci4510__project2=true" >> $GITHUB_OUTPUT; else echo "csci4510__project2=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci4510/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci4510__python_3_6=true" >> $GITHUB_OUTPUT; else echo "csci4510__python_3_6=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/csci4510/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "csci4510__rust=true" >> $GITHUB_OUTPUT; else echo "csci4510__rust=false" >> $GITHUB_OUTPUT; fi;
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep dockerfiles/submittyrpi/phil4140/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "phil4140__aris=true" >> $GITHUB_OUTPUT; else echo "phil4140__aris=false" >> $GITHUB_OUTPUT; fi;
+
+  # this job pushes container images for account "submittyrpi"
   push-images-submittyrpi:
     name: Push docker images (submittyrpi)
     runs-on: ubuntu-latest
+    needs: check-files-submittyrpi
     steps:
     - name: Check out repo
       uses: actions/checkout@v3
@@ -130,6 +282,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD_SUBMITTYRPI }}
 
     - name: Build and push submittyrpi/csci1200:default
+      if: needs.check-files-submittyrpi.outputs.csci1200__default == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci1200/default
@@ -137,6 +290,7 @@ jobs:
         tags: submittyrpi/csci1200:default
 
     - name: Build and push submittyrpi/csci2500:gdb
+      if: needs.check-files-submittyrpi.outputs.csci2500__gdb == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci2500/gdb
@@ -144,6 +298,7 @@ jobs:
         tags: submittyrpi/csci2500:gdb
 
     - name: Build and push submittyrpi/csci2500:spim
+      if: needs.check-files-submittyrpi.outputs.csci2500__spim == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci2500/spim
@@ -151,6 +306,7 @@ jobs:
         tags: submittyrpi/csci2500:spim
 
     - name: Build and push submittyrpi/csci2600:java_tools
+      if: needs.check-files-submittyrpi.outputs.csci2600__java_tools == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci2600/java_tools
@@ -158,6 +314,7 @@ jobs:
         tags: submittyrpi/csci2600:java_tools
 
     - name: Build and push submittyrpi/csci2600:java_tools_dafny
+      if: needs.check-files-submittyrpi.outputs.csci2600__java_tools_dafny == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci2600/java_tools_dafny
@@ -165,27 +322,31 @@ jobs:
         tags: submittyrpi/csci2600:java_tools_dafny
 
     - name: Build and push submittyrpi/csci4220:instructor_python
+      if: needs.check-files-submittyrpi.outputs.csci4220__instructor_python == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci4220/instructor_python
         push: true
         tags: submittyrpi/csci4220:instructor_python
 
-    - name: Build and push submittyrpi/csci4270:latest
-      uses: docker/build-push-action@releases/v3
-      with:
-        context: dockerfiles/submittyrpi/csci4270/20190912
-        push: true
-        tags: submittyrpi/csci4270:latest
-
     - name: Build and push submittyrpi/csci4270:20210121
+      if: needs.check-files-submittyrpi.outputs.csci4270__tag_20210121 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci4270/20210121
         push: true
         tags: submittyrpi/csci4270:20210121
 
+    - name: Build and push submittyrpi/csci4270:latest
+      if: needs.check-files-submittyrpi.outputs.csci4270__latest == 'true'
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: dockerfiles/submittyrpi/csci4270/20190912
+        push: true
+        tags: submittyrpi/csci4270:latest
+
     - name: Build and push submittyrpi/csci4380:latest
+      if: needs.check-files-submittyrpi.outputs.csci4380__latest == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci4380/latest
@@ -193,6 +354,7 @@ jobs:
         tags: submittyrpi/csci4380:latest
 
     - name: Build and push submittyrpi/csci4430:prolog_20191122
+      if: needs.check-files-submittyrpi.outputs.csci4430__prolog_20191122 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci4430/prolog_20191122
@@ -200,6 +362,7 @@ jobs:
         tags: submittyrpi/csci4430:prolog_20191122
 
     - name: Build and push submittyrpi/csci4450:soot
+      if: needs.check-files-submittyrpi.outputs.csci4450__soot == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci4450/soot
@@ -207,6 +370,7 @@ jobs:
         tags: submittyrpi/csci4450:soot
 
     - name: Build and push submittyrpi/csci4510:combined
+      if: needs.check-files-submittyrpi.outputs.csci4510__combined == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci4510/combined
@@ -214,6 +378,7 @@ jobs:
         tags: submittyrpi/csci4510:combined
 
     - name: Build and push submittyrpi/csci4510:default
+      if: needs.check-files-submittyrpi.outputs.csci4510__default == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci4510/default
@@ -221,6 +386,7 @@ jobs:
         tags: submittyrpi/csci4510:default
 
     - name: Build and push submittyrpi/csci4510:go
+      if: needs.check-files-submittyrpi.outputs.csci4510__go == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci4510/go
@@ -228,6 +394,7 @@ jobs:
         tags: submittyrpi/csci4510:go
 
     - name: Build and push submittyrpi/csci4510:java-11
+      if: needs.check-files-submittyrpi.outputs.csci4510__java_11 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci4510/java-11
@@ -235,6 +402,7 @@ jobs:
         tags: submittyrpi/csci4510:java-11
 
     - name: Build and push submittyrpi/csci4510:java-8
+      if: needs.check-files-submittyrpi.outputs.csci4510__java_8 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci4510/java-8
@@ -242,6 +410,7 @@ jobs:
         tags: submittyrpi/csci4510:java-8
 
     - name: Build and push submittyrpi/csci4510:project2
+      if: needs.check-files-submittyrpi.outputs.csci4510__project2 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci4510/project2
@@ -249,6 +418,7 @@ jobs:
         tags: submittyrpi/csci4510:project2
 
     - name: Build and push submittyrpi/csci4510:python-3.6
+      if: needs.check-files-submittyrpi.outputs.csci4510__python_3_6 == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci4510/python-3.6
@@ -256,6 +426,7 @@ jobs:
         tags: submittyrpi/csci4510:python-3.6
 
     - name: Build and push submittyrpi/csci4510:rust
+      if: needs.check-files-submittyrpi.outputs.csci4510__rust == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/csci4510/rust
@@ -263,6 +434,7 @@ jobs:
         tags: submittyrpi/csci4510:rust
 
     - name: Build and push submittyrpi/phil4140:aris
+      if: needs.check-files-submittyrpi.outputs.phil4140__aris == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: dockerfiles/submittyrpi/phil4140/aris

--- a/make_github_action.py
+++ b/make_github_action.py
@@ -1,10 +1,13 @@
 import json
 import os
 from pathlib import Path
+import random
+import re
 import sys
 
 # this script finds the metadata.json files and creates a github action file
 # with the appropriate steps to build and push the containers to dacker hub
+# one of the jobs looks for changed files to only push changed containers
 
 # to use this script run this in the repository root:
 # python3 make_github_action.py > .github/workflows/dockerhub_push.yml
@@ -31,12 +34,74 @@ dockerhub_accounts = {
     'submittyrpi': 'dockerfiles/submittyrpi'
 }
 
+# modify tags to ensure names are valid for github actions variable names
+tag_vars: dict[str,str] = dict()
+def tag_modifier(tag: str):
+    global tag_vars
+    if tag in tag_vars:
+        return tag_vars[tag]
+    if re.fullmatch(r'[_A-Za-z][_A-Za-z0-9]*',tag): # name is in proper format
+        tag_vars[tag] = tag
+        return tag
+    else: # try replacing invalid chars
+        newtag = ''.join(c if re.fullmatch(r'[_A-Za-z0-9]',c) else '_' for c in tag)
+        if not re.fullmatch(r'[_A-Za-z]',newtag[0]):
+            newtag = 'tag_' + newtag
+        if re.fullmatch(r'[_A-Za-z][_A-Za-z0-9]*',newtag):
+            tag_vars[tag] = newtag
+            return newtag
+        else: # pick something random
+            counter = 0 # prevent infinite loop
+            while True:
+                counter += 1
+                newtag = 'tag_' + str(random.randint(100000,999999))
+                if newtag not in tag_vars.values():
+                    tag_vars[tag] = newtag
+                    return newtag
+                assert counter < 1000
+
+# output start of the file checking job
+def account_job_check(username: str, infos):
+    ret = f'''\
+  # this job checks which containers for account "{username}" should be updated
+  check-files-{username}:
+    name: Check modified files ({username})
+    runs-on: ubuntu-latest
+    # variables that tell which containers should be updated
+    outputs:
+'''
+    for name,tag,dir in infos:
+        tag = tag_modifier(tag)
+        ret += f'''\
+      {name}__{tag}: ${{{{ steps.check-files-{username}.outputs.{name}__{tag} }}}}
+'''
+    ret += f'''\
+    steps:
+    - name: Code checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - name: Look for modified files
+      id: check-files-{username}
+      # look for whether any files were modified in the container's directory
+      run: |
+'''
+    for name,tag,dir in infos:
+        tag = tag_modifier(tag)
+        ret += f'''\
+        COUNT=$(git diff --name-only HEAD^ HEAD | grep {dockerhub_accounts[username]}/{name}/ | wc -l)
+        if [[ $COUNT != 0 ]]; then echo "{name}__{tag}=true" >> $GITHUB_OUTPUT; else echo "{name}__{tag}=false" >> $GITHUB_OUTPUT; fi;
+'''
+    return ret
+
 # output the start of a per-account job
 def account_job_start(username: str):
     return f'''\
+  # this job pushes container images for account "{username}"
   push-images-{username}:
     name: Push docker images ({username})
     runs-on: ubuntu-latest
+    needs: check-files-{username}
     steps:
     - name: Check out repo
       uses: actions/checkout@v3
@@ -51,6 +116,7 @@ def account_job_start(username: str):
 def account_container_string(username: str, name: str, tag: str, path: str):
     return f'''\
     - name: Build and push {username}/{name}:{tag}
+      if: needs.check-files-{username}.outputs.{name}__{tag_modifier(tag)} == 'true'
       uses: docker/build-push-action@releases/v3
       with:
         context: {path}
@@ -58,11 +124,10 @@ def account_container_string(username: str, name: str, tag: str, path: str):
         tags: {username}/{name}:{tag}
 '''
 
-print(file_start)
-
 # find all metadata.json files and create a job step for each
 def process_account(username: str, filepath: str):
     log_err(f'processing docker hub account {username}')
+    infos = [] # list of (name,tag,dir)
     # traverse the directory tree in sorted order to keep diff sizes small
     for dir,subdirs,files in sorted(os.walk(filepath)):
         if 'metadata.json' in files:
@@ -73,8 +138,19 @@ def process_account(username: str, filepath: str):
                 assert metadata['hostname'] == username
                 name = metadata['name']
                 tag = metadata['tag']
-                print(account_container_string(username,name,tag,dir))
-
-for username in sorted(dockerhub_accounts.keys()):
+                infos.append((name,tag,dir))
+    infos = sorted(infos)
+    print(account_job_check(username,infos))
     print(account_job_start(username))
-    process_account(username,dockerhub_accounts[username])
+    for name,tag,dir in infos:
+        log_err(f'processing {name}:{tag} in {dir}')
+        print(account_container_string(username,name,tag,dir))
+
+if __name__ == '__main__':
+    print(file_start)
+    for username in sorted(dockerhub_accounts.keys()):
+        process_account(username,dockerhub_accounts[username])
+    if False: # set to True to show tag name mappings
+        print('# tag name mapping:')
+        for k in tag_vars:
+            print('#',k,'->',tag_vars[k])

--- a/make_github_action.py
+++ b/make_github_action.py
@@ -1,0 +1,80 @@
+import json
+import os
+from pathlib import Path
+import sys
+
+# this script finds the metadata.json files and creates a github action file
+# with the appropriate steps to build and push the containers to dacker hub
+
+# to use this script run this in the repository root:
+# python3 make_github_action.py > .github/workflows/dockerhub_push.yml
+
+def log_err(a: str):
+    sys.stderr.write(a+'\n')
+
+# top of the github actions file
+file_start = '''\
+name: Push to Docker Hub
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+'''
+
+# dictionary mapping docker hub username/hostname to
+# a directory in this repository with the dockerfiles
+dockerhub_accounts = {
+    'submitty': 'dockerfiles/submitty',
+    'submittyrpi': 'dockerfiles/submittyrpi'
+}
+
+# output the start of a per-account job
+def account_job_start(username: str):
+    return f'''\
+  push-images-{username}:
+    name: Push docker images ({username})
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v3
+    - name: Docker Hub login
+      uses: docker/login-action@releases/v1
+      with:
+        username: ${{{{ secrets.DOCKER_USERNAME_{username.upper()} }}}}
+        password: ${{{{ secrets.DOCKER_PASSWORD_{username.upper()} }}}}
+'''
+
+# output a job step for pushing a container
+def account_container_string(username: str, name: str, tag: str, path: str):
+    return f'''\
+    - name: Build and push {username}/{name}:{tag}
+      uses: docker/build-push-action@releases/v3
+      with:
+        context: {path}
+        push: true
+        tags: {username}/{name}:{tag}
+'''
+
+print(file_start)
+
+# find all metadata.json files and create a job step for each
+def process_account(username: str, filepath: str):
+    log_err(f'processing docker hub account {username}')
+    # traverse the directory tree in sorted order to keep diff sizes small
+    for dir,subdirs,files in sorted(os.walk(filepath)):
+        if 'metadata.json' in files:
+            log_err(f'found metadata file {dir}/metadata.json')
+            with open(Path(dir,'metadata.json'),'r') as metafile:
+                metadata = json.load(metafile)
+                # docker hub username/hostname should match
+                assert metadata['hostname'] == username
+                name = metadata['name']
+                tag = metadata['tag']
+                print(account_container_string(username,name,tag,dir))
+
+for username in sorted(dockerhub_accounts.keys()):
+    print(account_job_start(username))
+    process_account(username,dockerhub_accounts[username])


### PR DESCRIPTION
This PR adds a script for generating the Github Actions file. It first runs a job to look for which containers have changed, by checking which directories the modified files are in. Then it pushes only the modified containers to Docker Hub.

I need more time to work on testing this, but I think it's ready for others to look at for feedback.

As far as I looked into, the tools provided for pushing to Docker Hub are mainly meant for single repositories dedicated to a container. For this, I had to create some of my own functionality to be able to handle several containers, each having their own directory, within a single repository.
