### PR TITLE
Fix typo in version tag

### DIFF
--- a/dockerfiles/submitty/autograding-default/Dockerfile
+++ b/dockerfiles/submitty/autograding-default/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get install -qqy imagemagick
 
 ENV DRMEMORY_TAG release_2.5.0
 ENV DRMEMORY_VERSION 2.5.0
-ENV AnalysisTools_Version v.22.03.00
+ENV AnalysisTools_Version v22.03.00
 ENV AnalysisToolsTS_Version v24.06.01
 ENV SUBMITTY_INSTALL_DIR /usr/local/submitty
 


### PR DESCRIPTION
Removed a dot in the version tag within the docker file which does not exist on the actual tag/release name.
See https://github.com/Submitty/AnalysisTools/releases/tag/v22.03.00 or https://github.com/Submitty/AnalysisTools/releases/download/v22.03.00/count

### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

### What is the new behavior?

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
