### PR TITLE
[Bugfix:Autograding] Typos w/ AnalysisTools Version Tags

### DIFF
--- a/dockerfiles/submitty/autograding-default/Dockerfile
+++ b/dockerfiles/submitty/autograding-default/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get install -qqy imagemagick
 
 ENV DRMEMORY_TAG release_2.5.0
 ENV DRMEMORY_VERSION 2.5.0
-ENV AnalysisTools_Version v.22.03.00
-ENV AnalysisToolsTS_Version v24.06.01
+ENV AnalysisTools_Version v22.03.00
+ENV AnalysisToolsTS_Version v23.06.01
 ENV SUBMITTY_INSTALL_DIR /usr/local/submitty
 
 RUN apt-get update \


### PR DESCRIPTION
Removed non-existing dot for AnalysisTools and changed to latest published version of AnalysisToolsTS

### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
* docker build failed with 404 for the wget commands

### What is the new behavior?
* docker build succeeds
