### PR TITLE
[Refactor:System] Update verilog spacing

### DIFF
--- a/dockerfiles/submitty/verilog/latest/Dockerfile
+++ b/dockerfiles/submitty/verilog/latest/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
       && rm -rf "/var/lib/apt/lists/*"
 
 RUN apt-get update \
-    && apt-get install -y iverilog gtkwave \
-    && rm -rf "/var/lib/apt/lists/*"
+      && apt-get install -y iverilog gtkwave \
+      && rm -rf "/var/lib/apt/lists/*"
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Verilog image isn't on Dockerhub

### What is the new behavior?
Verilog image should now be on Dockerhub after permission change

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
