### PR TITLE
[Bugfix:Autograding] Fix misnamed Java alias

### DIFF
--- a/dockerfiles/submitty/java/11/Dockerfile
+++ b/dockerfiles/submitty/java/11/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 RUN curl -L -o /adoptopenjdk.tar.gz https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_linux_11.0.12_7.tar.gz && \
     tar -xzf /adoptopenjdk.tar.gz -C /opt && \
     rm /adoptopenjdk.tar.gz && \
-    ln -s /opt/jdk-11.0.12+7 /opt/openjdk11
+    ln -s /opt/openjdk-11.0.12_7 /opt/openjdk11
 
 # Set environment variables
 ENV JAVA_HOME=/opt/openjdk11


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
/opt/openjdk11 is intended to be a link to the JDK installation folder, however the destination name is wrong. When /opt/openjdk11 is added to the path, it is unable to find the Java installation or run any java commands.

### What is the new behavior?
This fixes the destination name in the alias command. The path should now include the JDK and the image should successfully execute java commands.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
