### PR TITLE
[Feature:Autograding] Support multi-architecture builds

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -78,6 +78,9 @@ jobs:
           context: ${{ matrix.context }}
           push: true
           tags: submitty/${{ matrix.dockername }}:${{ matrix.tag }}
+          platforms:
+            - linux/arm64
+            - linux/amd64
   docker-latest:
     needs:
       - generate-matrix
@@ -100,3 +103,6 @@ jobs:
           context: ${{ matrix.context }}
           push: true
           tags: submitty/${{ matrix.dockername }}:latest
+          platforms:
+            - linux/arm64
+            - linux/amd64


### PR DESCRIPTION
### What is the current behavior?
Many developers use arm64-based Macs, but cannot run our Docker images which are built for amd64 architectures.

### What is the new behavior?
This PR adds support for multi-architecture builds.  If this works as expected, I plan to make a PR to the DockerImagesRPI repository with the same changes.

Related to https://github.com/Submitty/Submitty/issues/10461.