### PR TITLE
[Bugfix:Developer] Fix fork Docker org name

### DIFF
--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -10,6 +10,6 @@ jobs:
     uses: submitty/action-docker-build/.github/workflows/docker-build-push.yml@v24.07.00
     with:
       push: false
-      docker_org_name: ${{ vars.docker_org_name }}
+      docker_org_name: submitty
       base_commit: ${{ github.event.pull_request.base.sha }}
       head_commit: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -10,7 +10,7 @@ jobs:
     uses: submitty/action-docker-build/.github/workflows/docker-build-push.yml@v24.07.00
     with:
       push: true
-      docker_org_name: ${{ vars.docker_org_name }}
+      docker_org_name: submitty
       base_commit: ${{ github.event.before }}
       head_commit: ${{ github.event.after }}
     secrets:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
On PRs from forks, the Docker repo variable will not be sent to the GitHub action. This causes the action to fail since it is missing a required argument.

### What is the new behavior?
The action does not fail as the org name is now present.
