### PR TITLE
[Feature:Autograding] Add Rust Dockerfile

### DIFF
--- a/dockerfiles/rust/1.75/Dockerfile
+++ b/dockerfiles/rust/1.75/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:22.04
+
+RUN apt-get update
+
+# cargo 1.75.0 is latest version on apt as of 9/7/2024
+RUN apt install cargo=1.75.0+dfsg0ubuntu1~bpo0-0ubuntu0.22.04 -y
+

--- a/dockerfiles/rust/1.75/Dockerfile
+++ b/dockerfiles/rust/1.75/Dockerfile
@@ -1,7 +1,37 @@
 FROM ubuntu:22.04
 
-RUN apt-get update
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.75.0
 
-# cargo 1.75.0 is latest version on apt as of 9/7/2024
-RUN apt install cargo=1.75.0+dfsg0ubuntu1~bpo0-0ubuntu0.22.04 -y
-
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gcc \
+        libc6-dev \
+        wget \
+        ; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='f21c44b01678c645d8fbba1e55e4180a01ac5af2d38bcbd14aa665e0d96ed69a' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='673e336c81c65e6b16dcdede33f4cc9ed0f08bde1dbe7a935f113605292dc800' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='e7b0f47557c1afcd86939b118cbcf7fb95a5d1d917bdd355157b63ca00fc4333' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.26.0/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version; \
+    apt-get remove -y --auto-remove \
+        wget \
+        ; \
+    rm -rf /var/lib/apt/lists/*;

--- a/dockerfiles/rust/metadata.json
+++ b/dockerfiles/rust/metadata.json
@@ -1,0 +1,4 @@
+{
+    "pushLatest": true,
+    "latestTag": "1.75"
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

### What is the new behavior?

Creates a barebones Ubuntu image with the rust compiler (rustc) and package manager (cargo).

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Tested by creating a gradeable using this image and was able to compile and execute rust source in autograder.