### PR TITLE
[Feature:Autograding] Add image for latest Qiskit version

### DIFF
--- a/dockerfiles/qiskit/2.0.1/Dockerfile
+++ b/dockerfiles/qiskit/2.0.1/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:22.04
+
+RUN apt-get update
+
+RUN apt-get install python3.10 pip -y
+
+RUN pip install --upgrade pip==22.0.2
+
+RUN pip install qiskit[all]==2.0.1 qiskit-ibm-runtime==0.39.0

--- a/dockerfiles/qiskit/metadata.json
+++ b/dockerfiles/qiskit/metadata.json
@@ -1,4 +1,4 @@
 {
     "pushLatest": true,
-    "latestTag": "1.0.2"
+    "latestTag": "2.0.1"
 }


### PR DESCRIPTION
### What is the current behavior?
Current docker image only supports Qiskit 1.0.2.

### What is the new behavior?
Create new docker image that supports Qiskit 2.0.1 and set the latest tag to point to this image.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I ran the docker instance within the VM and executed python files that imported libraries no longer available in Qiskit 2.0.1, which failed as expected.
