### PR TITLE
[Feature:Autograding] add image for clang 14

### DIFF
--- a/dockerfiles/clang/14/Dockerfile
+++ b/dockerfiles/clang/14/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:22.04
+
+# installing requirements to get and extract prebuilt binaries
+RUN apt-get update
+RUN apt-get install -y clang-14 lld-14
+RUN rm -rf /var/lib/apt/lists/*
+
+# symlink
+RUN ln -s /usr/bin/clang++-14 /usr/bin/clang++

--- a/dockerfiles/clang/metadata.json
+++ b/dockerfiles/clang/metadata.json
@@ -1,4 +1,4 @@
 {
     "pushLatest": true,
-    "latestTag": "10"
+    "latestTag": "14"
 }


### PR DESCRIPTION
### What is the new behavior?

Adds a dockerfile for clang 14 (also bumps to ubuntu 22).
This version will work on ARM (previous version only worked on x86)