### PR TITLE
[Refactor:System] Remove submitty_count from default

### DIFF
--- a/dockerfiles/autograding-default/metadata.json
+++ b/dockerfiles/autograding-default/metadata.json
@@ -1,4 +1,4 @@
 {
     "pushLatest": true,
-    "latestTag": "ubuntu-22.04"
+    "latestTag": "ubuntu-22.04-v2"
 }

--- a/dockerfiles/autograding-default/ubuntu-22.04-v2/Dockerfile
+++ b/dockerfiles/autograding-default/ubuntu-22.04-v2/Dockerfile
@@ -71,7 +71,6 @@ RUN apt-get update \
     && chown -R root:${COURSE_BUILDERS_GROUP} ${SUBMITTY_INSTALL_DIR}/drmemory \
     && chmod -R 755 ${SUBMITTY_INSTALL_DIR}/drmemory \
     && mkdir -p ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools \
-    && wget -nv "https://github.com/Submitty/AnalysisTools/releases/download/${AnalysisTools_Version}/count" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools/count \
     && wget -nv "https://github.com/Submitty/AnalysisTools/releases/download/${AnalysisTools_Version}/plagiarism" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools/plagiarism \
     && wget -nv "https://github.com/Submitty/AnalysisTools/releases/download/${AnalysisTools_Version}/diagnostics" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools/diagnostics \
     && mkdir -p ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build \

--- a/dockerfiles/autograding-default/ubuntu-22.04/Dockerfile
+++ b/dockerfiles/autograding-default/ubuntu-22.04/Dockerfile
@@ -71,7 +71,6 @@ RUN apt-get update \
     && chown -R root:${COURSE_BUILDERS_GROUP} ${SUBMITTY_INSTALL_DIR}/drmemory \
     && chmod -R 755 ${SUBMITTY_INSTALL_DIR}/drmemory \
     && mkdir -p ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools \
-    && wget -nv "https://github.com/Submitty/AnalysisTools/releases/download/${AnalysisTools_Version}/count" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools/count \
     && wget -nv "https://github.com/Submitty/AnalysisTools/releases/download/${AnalysisTools_Version}/plagiarism" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools/plagiarism \
     && wget -nv "https://github.com/Submitty/AnalysisTools/releases/download/${AnalysisTools_Version}/diagnostics" -O ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools/diagnostics \
     && mkdir -p ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisToolsTS/build \


### PR DESCRIPTION
### What is the current behavior?
Fixes Submitty [Issue#11784](https://github.com/Submitty/Submitty/issues/11784) - This one of the companion PRs to Submitty [PR#12609](https://github.com/Submitty/Submitty/pull/12609). 

### What is the new behavior?
submitty_count is longer installed in preparation for deprecation.

### Other information?
<!-- Is this a breaking change? -->
This is a breaking change. Any autograding that uses the old submitty_count instead of submitty_count_ts will no longer work. 
<!-- How did you test -->
1. Follow the instructions on [this page](https://submitty.org/instructor/autograding/docker_images) up to step 6 with the Dockerfile modified in this PR. (you may be able to reuse the one I used `dagemcn/dockerimages:default-test` adding it through docker UI)
2. After you have added the new docker image with the DockerUI, update the config of any gradeable with `submitty_count` with 
```
"autograding_method": "docker",
"container_options": {
    "container_image": "IMAGE_NAME"
},
``` 
where `IMAGE_NAME` is the name of the image, for example, `dagemcn/dockerimages:default-test` if you reused mine.
3. Create a gradeable using submitty_count, (Tutorial examples 04, 06, and 07 all utilize submitty_count)
4. Test that submitty_count will not work in the config and that submitty_count_ts successfully runs
5. Also test that regular autograding works successfully on the image

Attached is a zip of a sample solution and gradeable config with both submitty_count and submitty_count_ts commands present for testing.
[example.zip](https://github.com/user-attachments/files/29638384/example.zip)
